### PR TITLE
chore: temporarily enable api mocking

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-API_MOCKING=disabled
+API_MOCKING=enabled

--- a/index.js
+++ b/index.js
@@ -9,10 +9,6 @@ import { ThemingProvider } from './src/theming';
 import { nativeServer as mswServer } from './src/mocks/msw/native';
 import { API_MOCKING } from '@env';
 
-if (API_MOCKING === 'enabled') {
-  mswServer.listen({ onUnhandledRequest: 'bypass' });
-}
-
 const queryClient = new QueryClient();
 
 const Main = () => {
@@ -26,5 +22,9 @@ const Main = () => {
 };
 
 AppRegistry.registerComponent(appName, () => Main);
+
+if (API_MOCKING === 'enabled') {
+  mswServer.listen({ onUnhandledRequest: 'bypass' });
+}
 
 export { Main };


### PR DESCRIPTION
As https://fakeql.com/ continues to be down, enable api mocking till issue is resolved (or switch to a different GraphQL provider).